### PR TITLE
Added support for GraphQL subscriptions - server side

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -361,6 +361,15 @@
 				"@types/underscore": "*"
 			}
 		},
+		"@types/ws": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/@types/ws/-/ws-6.0.3.tgz",
+			"integrity": "sha512-yBTM0P05Tx9iXGq00BbJPo37ox68R5vaGTXivs6RGh/BQ6QP5zqZDGWdAO6JbRE/iR1l80xeGAwCQS2nMV9S/w==",
+			"dev": true,
+			"requires": {
+				"@types/node": "*"
+			}
+		},
 		"@wry/equality": {
 			"version": "0.1.9",
 			"resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.1.9.tgz",
@@ -597,6 +606,11 @@
 			"requires": {
 				"underscore": ">=1.8.3"
 			}
+		},
+		"backo2": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
+			"integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc="
 		},
 		"balanced-match": {
 			"version": "1.0.0",
@@ -16578,6 +16592,14 @@
 				"iterall": "^1.2.2"
 			}
 		},
+		"graphql-subscriptions": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/graphql-subscriptions/-/graphql-subscriptions-1.1.0.tgz",
+			"integrity": "sha512-6WzlBFC0lWmXJbIVE8OgFgXIP4RJi3OQgTPa0DVMsDXdpRDjTsM1K9wfl5HSYX7R87QAGlvcv2Y4BIZa/ItonA==",
+			"requires": {
+				"iterall": "^1.2.1"
+			}
+		},
 		"graphql-tools": {
 			"version": "4.0.5",
 			"resolved": "https://registry.npmjs.org/graphql-tools/-/graphql-tools-4.0.5.tgz",
@@ -19323,6 +19345,28 @@
 			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
 			"dev": true
 		},
+		"subscriptions-transport-ws": {
+			"version": "0.9.16",
+			"resolved": "https://registry.npmjs.org/subscriptions-transport-ws/-/subscriptions-transport-ws-0.9.16.tgz",
+			"integrity": "sha512-pQdoU7nC+EpStXnCfh/+ho0zE0Z+ma+i7xvj7bkXKb1dvYHSZxgRPaU6spRP+Bjzow67c/rRDoix5RT0uU9omw==",
+			"requires": {
+				"backo2": "^1.0.2",
+				"eventemitter3": "^3.1.0",
+				"iterall": "^1.2.1",
+				"symbol-observable": "^1.0.4",
+				"ws": "^5.2.0"
+			},
+			"dependencies": {
+				"ws": {
+					"version": "5.2.2",
+					"resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
+					"integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
+					"requires": {
+						"async-limiter": "~1.0.0"
+					}
+				}
+			}
+		},
 		"superagent": {
 			"version": "3.8.3",
 			"resolved": "https://registry.npmjs.org/superagent/-/superagent-3.8.3.tgz",
@@ -19459,6 +19503,11 @@
 					}
 				}
 			}
+		},
+		"symbol-observable": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
+			"integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
 		},
 		"table": {
 			"version": "5.4.6",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
 		"@types/sinon": "^7.5.0",
 		"@types/supertest": "^2.0.8",
 		"@types/web3": "^1.0.19",
+		"@types/ws": "^6.0.3",
 		"chai": "^4.2.0",
 		"eslint": "^6.4.0",
 		"ganache-cli": "^6.7.0",
@@ -72,8 +73,10 @@
 		"bignumber.js": "^9.0.0",
 		"body-parser": "^1.19.0",
 		"graphql": "^14.5.8",
+		"graphql-subscriptions": "^1.1.0",
 		"graphql-tools": "^4.0.5",
 		"lodash": "^4.17.15",
+		"subscriptions-transport-ws": "^0.9.16",
 		"web3": "^1.2.1"
 	},
 	"prettier": {

--- a/src/graphql/index.ts
+++ b/src/graphql/index.ts
@@ -4,6 +4,9 @@ import { makeExecutableSchema } from 'graphql-tools';
 import { IContext } from './context';
 import { resolvers } from './resolvers';
 import { typeDefs } from './schema';
+import { execute, subscribe } from 'graphql';
+import { SubscriptionServer } from 'subscriptions-transport-ws';
+import { Server } from 'http';
 
 /**
  * Makes schema from schema definition (typeDefs) and resolvers (functions that resolve the requested query)
@@ -33,4 +36,30 @@ export function serveGraphQLRequest(
 	graphql({ schema, ...args }).then(result => {
 		res.send(result);
 	});
+}
+
+/**
+ * Using the server as the input, this function creates the subscription
+ * capabilities using Websocket for GraphQL. This means that time series data
+ * can be given to the client (for example the client can subscribe to data, and
+ * as the backend recieves the data one at a time, the data can slowly be pushed
+ * to the client rather than having to wait for all the data to arrive at the backend
+ * before pushing it to the client).
+ * ws://localhost:8080/subscriptions
+ * 
+ * A conceptual overview can be found on https://graphql.org/blog/subscriptions-in-graphql-and-relay/
+ * @param server http server, usually created from an express instance
+ */
+export function createGraphQLSubscription(server: Server) {
+	new SubscriptionServer(
+		{
+			execute,
+			subscribe,
+			schema: schema
+		},
+		{
+			server: server,
+			path: '/subscriptions'
+		}
+	);
 }

--- a/src/graphql/resolvers/hello-world-resolver.ts
+++ b/src/graphql/resolvers/hello-world-resolver.ts
@@ -1,8 +1,13 @@
+import { PubSub } from 'graphql-subscriptions';
 /**
  * Resolver for the Query localizedHelloWorld
  * What is a graphql resolver? https://www.apollographql.com/docs/apollo-server/data/data/#resolver-map
  * The schema that corresponds to this is in ../schema/hello-world.graphql
  */
+
+const HW_EVENT_ID = 'helloWorldEvent';
+const pubsub = new PubSub();
+let counter = 0;
 
 const resolver = {
 	Query: {
@@ -13,6 +18,22 @@ const resolver = {
 				cpp: "std::cout << 'Hello, World' << std::endl;",
 				javascript: "console.log('Hello, World')"
 			};
+		}
+	},
+	Subscription: {
+		helloWorldSubscription: {
+			subscribe: () => {
+				counter = 0;
+				const it = pubsub.asyncIterator(HW_EVENT_ID);
+				setInterval(() => {
+					pubsub.publish(HW_EVENT_ID, {
+						helloWorldSubscription: {
+							msg: `Hello, World - ${counter++}`
+						}
+					});
+				}, 200);
+				return it;
+			}
 		}
 	}
 };

--- a/src/graphql/schema/base.graphql
+++ b/src/graphql/schema/base.graphql
@@ -1,7 +1,17 @@
+schema {
+	query: Query
+	mutation: Mutation
+	subscription: Subscription
+}
+
 type Query {
 	_: Boolean
 }
 
 type Mutation {
+	_: Boolean
+}
+
+type Subscription {
 	_: Boolean
 }

--- a/src/graphql/schema/hello-world.graphql
+++ b/src/graphql/schema/hello-world.graphql
@@ -5,6 +5,14 @@ type LocalizedHelloWorld {
 	javascript: String!
 }
 
+type HelloWorldEvent {
+	msg: String!
+}
+
 extend type Query {
 	localizedHelloWorld: LocalizedHelloWorld!
+}
+
+extend type Subscription {
+	helloWorldSubscription: HelloWorldEvent!
 }

--- a/src/graphql/schema/index.ts
+++ b/src/graphql/schema/index.ts
@@ -1,9 +1,19 @@
 export const typeDefs = `
+schema {
+	query: Query
+	mutation: Mutation
+	subscription: Subscription
+}
+
 type Query {
 	_: Boolean
 }
 
 type Mutation {
+	_: Boolean
+}
+
+type Subscription {
 	_: Boolean
 }
 
@@ -14,10 +24,17 @@ type LocalizedHelloWorld {
 	javascript: String!
 }
 
+type HelloWorldEvent {
+	msg: String!
+}
+
 extend type Query {
 	localizedHelloWorld: LocalizedHelloWorld!
 }
 
+extend type Subscription {
+	helloWorldSubscription: HelloWorldEvent!
+}
 type Descriptor {
 	unit: String!
 	value: Float!

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,7 +1,8 @@
 import bodyparser from 'body-parser';
 import express from 'express';
-import { serveGraphQLRequest } from './graphql';
+import { serveGraphQLRequest, createGraphQLSubscription } from './graphql';
 import { Context } from './graphql/context';
+import { createServer } from 'http';
 
 const PORT = 8080;
 
@@ -29,7 +30,10 @@ app.post('/graphql', (req, res) => {
 	);
 });
 
-export const server = app.listen(PORT, () => {
+export const server = createServer(app);
+
+server.listen(PORT, () => {
+	createGraphQLSubscription(server);
 	console.log(`Express server initialized on port ${PORT}`);
 	console.log(
 		`GraphQL requests are enabled on /graphql endpoint via POST requests`

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,8 @@
 		"sourceMap": true,
 		"strict": true,
 		"esModuleInterop": true,
-		"noImplicitAny": true
+		"noImplicitAny": true,
+		"lib": ["esnext.asynciterable"]
 	},
 	"exclude": ["bin", "node-tests"]
 }


### PR DESCRIPTION
Subscriptions will let us send smaller amounts of data over time instead of a whole array of data at once. In the demo, we talked about having a really long delay for a large amount of data queried from the blockchain. This should help in alleviating the response time of the first response from the blockchain although I suspect the overall response time will increase (which I think is okay).